### PR TITLE
fix: boolean parameter input when default is True

### DIFF
--- a/frontend/src/components/JsonSchemaForm.tsx
+++ b/frontend/src/components/JsonSchemaForm.tsx
@@ -107,8 +107,10 @@ const renderers: Record<FieldType, (field: FieldDefinition) => JSX.Element> = {
     )
   },
   text: (field: FieldDefinition) => {
+    const inputType = field.value.format === 'password' ? "password" : "text"
     return (
       <TextInput
+        type={inputType}
         name={field.name}
         placeholder={field.label}
         defaultValue={field.defaultValue}

--- a/frontend/src/components/JsonSchemaForm.tsx
+++ b/frontend/src/components/JsonSchemaForm.tsx
@@ -33,6 +33,14 @@ const renderers: Record<FieldType, (field: FieldDefinition) => JSX.Element> = {
     return (
       <div className="flex items-center mb-4">
         <input
+          id={`${field.name}_hidden`}
+          name={field.name}
+          type="hidden"
+          checked={true}
+          readOnly={true}
+          value="false"
+        />
+        <input
           id={field.name}
           name={field.name}
           type="checkbox"


### PR DESCRIPTION
Problem: 
when using a `boolean` parameter value with `default=True` it cannot be set to `False` via the input form.

Booleans are rendered as HTML input checkboxes and the value is only sent if checked. 

This PR fixes this issue by renderering a hidden input with the same name, setting the value to `false`. 