### PR TITLE
Add error messages in auth_redirect endpoint

### DIFF
--- a/src/plombery/api/authentication.py
+++ b/src/plombery/api/authentication.py
@@ -80,8 +80,15 @@ def build_auth_router(app: FastAPI) -> APIRouter:
 
     @router.get("/redirect")
     async def auth_redirect(request: Request):
-        token = await oauth_client.authorize_access_token(request)
-        user = token["userinfo"]
+        try:
+            token = await oauth_client.authorize_access_token(request)
+        except Exception as e:
+            raise HTTPException(401, f"Unable to authenticate. Error: {str(e)}")
+
+        try:
+            user = token["userinfo"]
+        except:
+            raise HTTPException(401, "Unable to authenticate. Error: No user info")
 
         if user:
             request.session["user"] = dict(user)


### PR DESCRIPTION
Added meaningful error messages in the authentication redirect endpoint, to show the user the error when the authorization breaks, instead of the Internal server error message that was displayed before.