### PR TITLE
fix(oauth): fixed generic oauth provider

### DIFF
--- a/docs/configuration/auth/generic-oauth.md
+++ b/docs/configuration/auth/generic-oauth.md
@@ -2,9 +2,9 @@
 icon: material/lock
 ---
 
-Plombery has a buil-in and ready-to-use authentication system
+Plombery has a built-in and ready-to-use authentication system
 based on OAuth providers, so you can use your corporate auth system
-or Google, Github, etc. as long as they're compatible with OAuth.
+or Google, GitHub, etc. as long as they're compatible with OAuth.
 
 To enable the auth system you just need to configure it via the `yml`
 config file.
@@ -28,9 +28,8 @@ Options available
 
 *from v0.5.0*
 
-Can be `microsoft` of `google`, if this field is present, then the client id and secret are required.
-
-If using Microsoft, then you can also use `microsoft_tenant_id`, check the dedicated page.
+Provider is `generic`
+See dedicated pages for others providers on how to configure them.
 
 ### `client_id`
 
@@ -39,10 +38,6 @@ An OAuth app client ID
 ### `client_secret`
 
 An OAuth app client secret
-
-### `microsoft_tenant_id`
-
-The Microsoft tenant ID to be used when using the `provider: microsoft` option.
 
 ### `server_metadata_url`
 

--- a/src/plombery/auth/providers.py
+++ b/src/plombery/auth/providers.py
@@ -4,24 +4,33 @@ from plombery.config.model import AuthSettings
 from plombery.config import settings
 
 
-def _get_google(settings: AuthSettings):
+def _get_google(auth_settings: AuthSettings):
     return {
         "name": "Google",
         "metadata_url": "https://accounts.google.com/.well-known/openid-configuration",
     }
 
 
-def _get_microsoft(settings: AuthSettings):
+def _get_microsoft(auth_settings: AuthSettings):
     return {
         "name": "Microsoft",
-        "metadata_url": f"https://login.microsoftonline.com/{settings.microsoft_tenant_id or 'common'}/v2.0/.well-known/openid-configuration",
+        "metadata_url": f"https://login.microsoftonline.com/{auth_settings.microsoft_tenant_id or 'common'}/v2.0/.well-known/openid-configuration",
         "client_kwargs": {"scope": "openid email profile"},
+    }
+
+
+def _get_generic(auth_settings: AuthSettings):
+    return {
+        "name": "OAuth",
+        "metadata_url": auth_settings.server_metadata_url,
+        "client_kwargs": auth_settings.client_kwargs,
     }
 
 
 _AUTH_PROVIDERS: dict[str, Callable[[AuthSettings], dict]] = {
     "google": _get_google,
     "microsoft": _get_microsoft,
+    "generic": _get_generic
 }
 
 


### PR DESCRIPTION
Added Generic OAuth and included this in doc. This fixes issue: #538

Settings was renamed to auth_settings as to not confuse with outer scope.

Removed Microsoft tenant id from generic auth doc. Generic should only care for generic info, not Microsoft.

Introduced method for generic auth. However, providers should've maybe produced by a factory, and enforced via type hints.