### PR TITLE
test: reset orchestrator state between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,14 @@ from pathlib import Path
 
 import pytest
 
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
 from plombery import _Plombery
 from plombery.config import settings
 from plombery.config.model import AuthSettings
 from plombery.api import app as fastapi_app
 from plombery.api.authentication import _needs_auth
+from plombery.orchestrator import orchestrator
 
 
 def _bypass_auth():
@@ -56,3 +59,24 @@ def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_orchestrator():
+    """Reset the module-global orchestrator's state between tests.
+
+    The orchestrator's scheduler binds to the event loop running when
+    `start()` is first called; subsequent tests get a fresh event loop
+    (see the `event_loop` fixture) but APScheduler still holds the closed
+    one, raising `RuntimeError: Event loop is closed`. Likewise the
+    orchestrator's class-level pipeline/trigger registries persist across
+    tests. Resetting both ensures each test starts clean.
+
+    We replace the scheduler with a fresh instance rather than calling
+    shutdown() on the old one — shutdown itself schedules work on the
+    (already-closed) event loop and raises.
+    """
+    yield
+    orchestrator.scheduler = AsyncIOScheduler()
+    orchestrator._all_pipelines.clear()
+    orchestrator._all_triggers.clear()


### PR DESCRIPTION
## Why

The module-global `orchestrator` (`plombery.orchestrator.orchestrator`) holds class-level pipeline/trigger registries and an APScheduler that latches onto the first event loop it sees. With pytest-asyncio's per-test `event_loop` fixture, the scheduler ends up holding a closed loop after the first async test, and any second async test that submits a job hits:

\`\`\`
RuntimeError: Event loop is closed
\`\`\`

The current test suite has only one async test (test_logging.py::test_pipeline_logs_are_correclty_captured), so the bug is latent. Any second async test exposes it. To verify on \`main\`:

\`\`\`
$ uv run pytest tests/test_logging.py tests/test_logging.py
...
RuntimeError: Event loop is closed
1 failed, 1 passed
\`\`\`

This blocks adding new async tests that exercise the orchestrator — including the regression test for #491 in a follow-up PR.

## What

Adds an autouse \`reset_orchestrator\` fixture that, after each test:

- replaces \`orchestrator.scheduler\` with a fresh \`AsyncIOScheduler()\` so the next test rebinds to the next event loop
- clears \`_all_pipelines\` and \`_all_triggers\` so the next test starts with no registered pipelines

We replace the scheduler rather than calling \`shutdown(wait=False)\` because \`shutdown\` itself schedules cleanup work on the (already-closed) loop and would raise during teardown.

## Scope

Test infrastructure only — no production code touched. All existing tests continue to pass:

\`\`\`
$ uv run pytest tests/
6 passed, 1 skipped, 7 warnings in 1.05s
\`\`\`

## Followup

This is a prerequisite for #XXX (issue #491 task-logger fd leak fix), which adds an async regression test that needs this isolation.