### PR TITLE
build: include static, email_templates, alembic.ini in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,13 @@ version = { attr = "plombery._version.__version__" }
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+plombery = [
+  "static/**/*",
+  "notifications/email_templates/**/*",
+  "alembic/alembic.ini",
+]
+
 [tool.pytest.ini_options]
 env = ["DATABASE_URL=sqlite:///:memory:", "TESTING=true"]
 


### PR DESCRIPTION
## Why

`MANIFEST.in` currently lists the frontend bundle, email templates, and `alembic.ini`:

```
recursive-include src/plombery/static *
recursive-include src/plombery/notifications/email_templates *
include README.md
include src/plombery/alembic/alembic.ini
```

This works for **sdist** (`.tar.gz`) builds but is silently ignored for **wheel** builds. setuptools' wheel backend uses `[tool.setuptools.package-data]` from `pyproject.toml` for non-Python file inclusion, not `MANIFEST.in`.

The result: anyone who builds a wheel from source — `pip install <repo-path>`, `uv pip install`, `pip wheel .`, etc. — gets a wheel with an empty `static/` directory. The server starts fine, the API works (`GET /api/pipelines/` → 200), but the SPA mount serves 404 for every UI route because there's no `index.html` to serve.

I hit this trying to install from a fork: the install completes silently, the launchd-supervised process starts, the API endpoints answer correctly, but `http://localhost:8000/` returns 404. It took a fair amount of digging to realize the build had silently dropped the JS/HTML/CSS.

The PyPI wheels likely include the static files because of whatever ad-hoc build flow ships them (CI? custom build script?), but this means **building a wheel from source produces a different artifact than what's on PyPI** — which is a footgun for anyone doing `pip install <fork-or-local>`.

## What

Add a `[tool.setuptools.package-data]` section to `pyproject.toml` mirroring what `MANIFEST.in` already declares:

```toml
[tool.setuptools.package-data]
plombery = [
  "static/**/*",
  "notifications/email_templates/**/*",
  "alembic/alembic.ini",
]
```

Now wheels built from source contain the same files as the sdist contains. `MANIFEST.in` could arguably be deleted, but I left it alone so this PR is minimal and reviewers can see the wheel/sdist parity intent.

## Verification

Build a wheel against `main` (with frontend pre-built via `pnpm build`) and inspect:

**Before this change:**
```
$ unzip -l plombery-0.5.2-py3-none-any.whl | grep -E 'static/|email_templates/|alembic.ini'
# (no matches — files dropped)
```

**After:**
```
$ unzip -l plombery-0.5.2-py3-none-any.whl | grep -E 'static/|email_templates/|alembic.ini'
     4799  ...  plombery/alembic/alembic.ini
     8505  ...  plombery/notifications/email_templates/transactional.html
      826  ...  plombery/static/index.html
   124458  ...  plombery/static/assets/main-DAkYjylT.js
       …
```

Server install via `uv pip install <local-path>` then renders the SPA correctly:

```
$ curl -o /dev/null -w '%{http_code}\n' http://localhost:8000/
200
```

Independent of PR #543 / #544.